### PR TITLE
Re-enable fcurves without a group, more PEP8 formatting/cleanup and etc

### DIFF
--- a/cur_utils.py
+++ b/cur_utils.py
@@ -58,7 +58,7 @@ def get_selected(fcurves):
     selected = []
 
     for fcurve in fcurves:
-        if fcurve.group.name == group_name:
+        if getattr(fcurve.group, 'name', None) == group_name:
             continue        # we don't want to add to the list the helper curves we have created
 
         if fcurve.select:
@@ -84,7 +84,7 @@ def remove_helpers(objects):
         # arefe.fcurve.index = -1
 
         for fcurve in action.fcurves:     # delete the first of the clones left
-            if fcurve.group.name == group_name:
+            if getattr(fcurve.group, 'name', None) == group_name:
                 action.fcurves.remove(fcurve)
                 # aclones.remove(0)
 
@@ -148,12 +148,8 @@ def duplicate(fcurve, selected_keys=True, before='NONE', after='NONE', lock=Fals
     action.groups[group_name].lock = lock
     action.groups[group_name].color_set = 'THEME10'
 
-    i = 0
-
-    for index, key in selected_keys:
+    for i, (index, key) in enumerate(selected_keys):
         dup.keyframe_points[i].co = key.co
-
-        i += 1
 
     add_cycle(dup, before=before, after=after)
 
@@ -203,7 +199,7 @@ def s_curve(x, slope=1.0, width=1.0, height=1.0, xshift=0.0, yshift=0.0):
     '''
     Formula for "s" curve
     '''
-    return height*((x-xshift)**slope/((x-xshift)**slope+(width-(x-xshift))**slope))+yshift
+    return height * ((x - xshift) ** slope / ((x - xshift) ** slope + (width - (x - xshift)) ** slope)) + yshift
 
 
 def ramp_curve(x, slope=2.0, height=1.0, yshift=0.0, width=1.0, xshift=0.0, invert=False):
@@ -249,10 +245,7 @@ def from_clone_to_reference(objects, factor, clone_selected_keys=False):
         aclone_index = 0
         for fcurve in action.fcurves:
 
-            if fcurve.select is False:
-                continue
-
-            if fcurve.hide:
+            if not fcurve.select or fcurve.hide:
                 continue
 
             if 'clone' in fcurve.data_path:
@@ -282,8 +275,7 @@ def from_clone_to_reference(objects, factor, clone_selected_keys=False):
                 if key is None:
                     return
 
-            n = 0
-            for index in selected_keys:
+            for n, index in enumerate(selected_keys):
                 key = fcurve.keyframe_points[index]
                 if clone_selected_keys is True:
                     i = n
@@ -295,7 +287,6 @@ def from_clone_to_reference(objects, factor, clone_selected_keys=False):
                 # target_y = reference.evaluate(key.co.x)
                 # diference = target_y - key.co.y
                 # key.co.y = key.co.y + diference * ((factor + 1)/2)
-                n += 1
 
             fcurve.update()
             refe.remove(action, reference)
@@ -310,14 +301,11 @@ def add_clone(objects, cycle_before='NONE', cycle_after="NONE", selected_keys=Fa
     for obj in objects:
         fcurves = obj.animation_data.action.fcurves
 
-        for fcurve_index, fcurve in fcurves.items():
-            if fcurve.group.name == group_name:
+        for fcurve in fcurves:
+            if getattr(fcurve.group, 'name', None) == group_name:
                 continue  # we don't want to add to the list the helper curves we have created
 
-            if fcurve.hide is True:
-                continue
-
-            if fcurve.select is False:
+            if fcurve.hide or not fcurve.select:
                 continue
 
             duplicate(fcurve, selected_keys=selected_keys, before=cycle_before, after=cycle_after)

--- a/key_utils.py
+++ b/key_utils.py
@@ -443,7 +443,7 @@ def get_sliders_globals(selected=True, original=True, left_frame=None, right_fra
     Gets all the global values needed to work with the sliders
     '''
 
-    context = bp.context
+    context = bpy.context
     animaide = context.scene.animaide
 
     if context.space_data.dopesheet.show_only_selected:

--- a/key_utils.py
+++ b/key_utils.py
@@ -73,10 +73,7 @@ def move_right_left(objects, amount, direction='RIGHT', lock=True):
 
         for fcurve in action.fcurves:
 
-            if fcurve.select is False:
-                continue
-
-            if fcurve.hide is True:
+            if not fcurve.select or fcurve.hide:
                 continue
 
             selected_keys = get_selected(fcurve)
@@ -138,10 +135,10 @@ def move(fcurve, key, amount, direction='RIGHT'):
     if direction == 'UP':
         key.co.y = key.co.y + amount
 
-    if direction == 'DOWN':
+    elif direction == 'DOWN':
         key.co.y = key.co.y - amount
 
-    if direction == 'LEFT':
+    elif direction == 'LEFT':
         key.co.x = key.co.x - int(amount)
         if left_neighbor is not None:
             if key.co.x == left_neighbor.co.x:
@@ -211,7 +208,6 @@ def set_value(key, str):
     sets the value of the current key to the numeric value of "str"
     if "+" or "-" is used the it will perform the corresponding math operation
     '''
-
 
     key_value = key.co.y
     if str.startswith('+'):
@@ -317,27 +313,22 @@ def handles(objects, act_on='ALL', left=None, right=None, control_point=None, ha
                     if handle_type is not None:
                         handle_set_type(key, left=left, right=right, handle_type=handle_type)
 
-            elif act_on == 'ALL':
-                for index, key in fcurve.keyframe_points.items():
-                    print('all')
-                    if handle_type is not None:
-                        handle_set_type(key, left=True, right=True, handle_type=handle_type)
-
-            elif act_on == 'FIRST':
-                print('first')
-                if handle_type is not None:
-                    handle_set_type(first_key, left=True, right=True, handle_type=handle_type)
-
-            elif act_on == 'LAST':
-                print('last')
-                if handle_type is not None:
-                    handle_set_type(last_key, left=True, right=True, handle_type=handle_type)
-
-            elif act_on == 'BOTH':
-                print('both')
-                if handle_type is not None:
-                    handle_set_type(last_key, left=True, right=True, handle_type=handle_type)
-                    handle_set_type(first_key, left=True, right=True, handle_type=handle_type)
+            elif handle_type is not None:
+                kwargs = dict(left=True, right=True, handle_type=handle_type)
+                if act_on == 'ALL':
+                    for index, key in fcurve.keyframe_points.items():
+                        print('all')
+                        handle_set_type(key, **kwargs)
+                elif act_on == 'FIRST':
+                    print('first')
+                    handle_set_type(first_key, **kwargs)
+                elif act_on == 'LAST':
+                    print('last')
+                    handle_set_type(last_key, **kwargs)
+                elif act_on == 'BOTH':
+                    print('both')
+                    handle_set_type(last_key, **kwargs)
+                    handle_set_type(first_key, **kwargs)
 
             fcurve.update()
 
@@ -347,15 +338,14 @@ def handle_manipulate(key, left=None, right=None, length=None):
     set length of a key handles
     '''
 
-    if left is not None:
-        if left is True:
-            if length is not None:
-                key.handle_left.length = length
+    if length is None:
+        return
 
-    if right is not None:
-        if right is True:
-            if length is not None:
-                key.handle_right.length = length
+    if left is True:
+        key.handle_left.length = length
+
+    if right is True:
+        key.handle_right.length = length
 
 
 def handle_set_type(key, left=True, right=True, handle_type='AUTO_CLAMPED'):
@@ -363,13 +353,11 @@ def handle_set_type(key, left=True, right=True, handle_type='AUTO_CLAMPED'):
     set "type" of a key handles
     '''
 
-    if left is not None:
-        if left is True:
-            key.handle_left_type = handle_type
+    if left is True:
+        key.handle_left_type = handle_type
 
-    if left is not None:
-        if right is True:
-            key.handle_right_type = handle_type
+    if right is True:
+        key.handle_right_type = handle_type
 
 
 def attach_selection_to_fcurve(fcurve, target_fcurve, factor=1.0, is_gradual=True):
@@ -410,10 +398,7 @@ def get_selected(fcurve):
     keys = fcurve.keyframe_points
     keyframe_indexes = []
 
-    if fcurve.group is None:
-        return
-
-    if fcurve.group.name == cur_utils.group_name:
+    if getattr(fcurve.group, 'name', None) == cur_utils.group_name:
         return []  # we don't want to select keys on reference fcurves
 
     for index, key in keys.items():
@@ -425,22 +410,14 @@ def get_selected(fcurve):
 
 def valid_anim(obj):
     '''
-    checks if the obj has animation data
+    checks if the obj has an active action
     '''
 
     anim = obj.animation_data
+    action = getattr(anim, 'action', None)
+    fcurves = getattr(action, 'fcurves', None)
 
-    if anim is None:
-        return False
-
-    elif anim.action is None:
-        return False
-
-    elif anim.action.fcurves is None:
-        return False
-
-    else:
-        return True
+    return bool(fcurves)
 
 
 def valid_fcurve(fcurve):
@@ -453,18 +430,10 @@ def valid_fcurve(fcurve):
         if fcurve.select is False:
             return False
 
-    if fcurve.lock is True:
+    if fcurve.lock or fcurve.hide:
         return False
-
-    if fcurve.hide is True:
-        return False
-
-    if fcurve.group is None:
-        return False
-
-    if fcurve.group.name == cur_utils.group_name:
+    elif getattr(fcurve.group, 'name', None) == cur_utils.group_name:
         return False  # we don't want to select keys on reference fcurves
-
     else:
         return True
 
@@ -474,10 +443,11 @@ def get_sliders_globals(selected=True, original=True, left_frame=None, right_fra
     Gets all the global values needed to work with the sliders
     '''
 
-    animaide = bpy.context.scene.animaide
+    context = bp.context
+    animaide = context.scene.animaide
 
-    if bpy.context.space_data.dopesheet.show_only_selected == True:
-        objects = bpy.context.selected_objects
+    if context.space_data.dopesheet.show_only_selected:
+        objects = context.selected_objects
     else:
         objects = bpy.data.objects
 
@@ -533,7 +503,7 @@ def get_sliders_globals(selected=True, original=True, left_frame=None, right_fra
                 else:
                     nextkey_value = fcurve.keyframe_points[key_index + 1].co.y
 
-                smooth = (prevkey_value + key.co.y + nextkey_value)/3
+                smooth = (prevkey_value + key.co.y + nextkey_value) / 3
                 values[key_index]['sy'] = smooth
 
             if not keyframes:
@@ -788,9 +758,9 @@ def delete(objects, kind=None):
                 if kind is None:
                     print('delete for None')
                     obj.keyframe_delete(fcurve.data_path,
-                                           fcurve.array_index,
-                                           key.co.x,
-                                           fcurve.group.name)
+                                        fcurve.array_index,
+                                        key.co.x,
+                                        fcurve.group.name)
                 elif \
                         kind == 'KEYFRAME' or \
                         kind == 'BREAKDOWN' or \
@@ -798,9 +768,9 @@ def delete(objects, kind=None):
                     if key.type == kind:
                         print('delete for ', kind)
                         obj.keyframe_delete(fcurve.data_path,
-                                               fcurve.array_index,
-                                               key.co.x,
-                                               fcurve.group.name)
+                                            fcurve.array_index,
+                                            key.co.x,
+                                            fcurve.group.name)
                     else:
                         index += 1
                 fcurve.update()
@@ -823,10 +793,7 @@ def flatten(objects, side):
 
         for fcurve in action.fcurves:
 
-            if fcurve.group is None:
-                continue
-
-            if fcurve.group.name == cur_utils.group_name:
+            if getattr(fcurve.group, 'name', None) == cur_utils.group_name:
                 continue  # we don't want to add to the list the helper curves we have created
 
             if fcurve.select is False:
@@ -927,7 +894,7 @@ def get_frame_neighbors(fcurve, frame=None, clamped=False):
         frame = bpy.context.scene.frame_current
     fcurve_keys = fcurve.keyframe_points
     left_neighbor = fcurve_keys[0]
-    right_neighbor = fcurve_keys[len(fcurve_keys)-1]
+    right_neighbor = fcurve_keys[len(fcurve_keys) - 1]
 
     for key in fcurve.keyframe_points:
         dif = key.co.x - frame
@@ -950,9 +917,6 @@ def get_frame_neighbors(fcurve, frame=None, clamped=False):
 
 
 def calculate_delta(key, previous_key, next_key):
-    '''
-
-    '''
 
     frames_gap = abs(next_key.co.x - previous_key.co.x)  # frames between keys
     key_pos = abs(key.co.x - previous_key.co.x)  # frame position of the key in question
@@ -963,6 +927,3 @@ def calculate_delta(key, previous_key, next_key):
         return 0.25     # in the case of the fist or last key
     else:
         return ((key_pos * 100) / frames_gap) / 100
-
-
-

--- a/ops.py
+++ b/ops.py
@@ -19,7 +19,8 @@ Created by Ares Deveaux
 '''
 
 
-import bpy, os
+import bpy
+import os
 
 from . import utils, key_utils, cur_utils, slider_tools, magnet
 from bpy.props import StringProperty, EnumProperty, BoolProperty, \
@@ -27,7 +28,7 @@ from bpy.props import StringProperty, EnumProperty, BoolProperty, \
 from bpy.types import Operator
 
 
-################  SLIDERS  ###############
+# ###############  SLIDERS  ###############
 
 
 class AAT_OT_ease_to_ease(Operator):
@@ -753,7 +754,7 @@ Removes last slider of the list'''
         # if len(slots) > 1:
         index = len(slots) - 1
         slots.remove(index)
-        slider_tools.remove_marker(index+2)
+        slider_tools.remove_marker(index + 2)
 
         return {'FINISHED'}
 
@@ -808,15 +809,19 @@ one on the right sets the right reference'''
             slider.right_ref_frame = current_frame
 
         if slider.use_markers:
-            slider_tools.add_marker(name_a='F',
-                             name_b=slider_num,
-                             side=self.side,
-                             frame=current_frame)
+            slider_tools.add_marker(
+                name_a='F',
+                name_b=slider_num,
+                side=self.side,
+                frame=current_frame
+            )
         else:
             for side in ['L', 'R']:
-                slider_tools.remove_marker(name_a='F',
-                                    name_b=slider_num,
-                                    side=side)
+                slider_tools.remove_marker(
+                    name_a='F',
+                    name_b=slider_num,
+                    side=side
+                )
             # utils.remove_marker(slider_num)
 
         # key_utils.get_ref_frame_globals(slider.left_neighbor, slider.right_neighbor)
@@ -836,7 +841,7 @@ one on the right sets the right reference'''
         return {'FINISHED'}
 
 
-################  ANIM TRANSFORM  ###############
+# ###############  ANIM TRANSFORM  ###############
 
 
 class AAT_OT_create_anim_trans_mask(Operator):
@@ -992,7 +997,7 @@ Options related to the anim_transform'''
         # row.prop(animaide.anim_transform, 'interp', text='', icon_only=False)
 
 
-################  HELP  ###############
+# ###############  HELP  ###############
 
 
 class AAT_OT_help(Operator):
@@ -1069,7 +1074,7 @@ Opens Animaide manual'''
         return {'FINISHED'}
 
 
-################  OTHER TOOLS  ###############
+# ###############  OTHER TOOLS  ###############
 
 
 class AAT_OT_clone(Operator):
@@ -1213,9 +1218,3 @@ classes = (
     AAT_OT_create_anim_trans_mask,
     AAT_OT_delete_anim_trans_mask
 )
-
-
-
-
-
-

--- a/props.py
+++ b/props.py
@@ -72,7 +72,7 @@ def update_clone_move(self, context):
 def update_clone(self, context):
 
     objects = context.selected_objects
-    animaide = bpy.context.scene.animaide
+    animaide = context.scene.animaide
     cycle_before = animaide.clone_data.cycle_before
     cycle_after = animaide.clone_data.cycle_after
 
@@ -100,32 +100,6 @@ def update_selector(self, context):
     self.modal_switch = False
 
 
-def toggle_sliders_markers(self, context):
-    # Add a marker when a reference frame is created
-
-    n = 0
-    if self.use_markers:
-        for side in ['L', 'R']:
-            if side == 'L':
-                frame = self.left_ref_frame
-            else:
-                frame = self.right_ref_frame
-
-            utils.add_marker(name_a='F',
-                             name_b=0,
-                             side=side,
-                             frame=frame,
-                             overwrite_name=False)
-            n += 1
-    else:
-        for side in ['L', 'R']:
-            utils.remove_marker(name_a='F',
-                                name_b=0,
-                                side=side)
-
-    return
-
-
 class AnimAideAnimTransform(PropertyGroup):
 
     active: BoolProperty()
@@ -137,13 +111,13 @@ class AnimAideAnimTransform(PropertyGroup):
     #                           update=toggle_anim_trans_markers)
 
     mask_margin_l: IntProperty(default=0,
-                          description="Margin for the mask")
+                               description="Margin for the mask")
     mask_blend_l: IntProperty(default=0, max=0,
-                         description="Fade value for the left margin")
+                              description="Fade value for the left margin")
     mask_margin_r: IntProperty(default=0,
-                          description="Margin for the mask")
+                               description="Margin for the mask")
     mask_blend_r: IntProperty(default=0, min=0,
-                         description="Fade value for the right margin")
+                              description="Fade value for the right margin")
 
     mask_blend_mapping: FloatProperty()
 
@@ -174,9 +148,9 @@ class AnimAideClone(PropertyGroup):
                                update=update_clone_move)
 
     cycle_options = [('NONE', 'None', '', '', 1),
-                    ('REPEAT', 'Repeat', '', '', 2),
-                    ('REPEAT_OFFSET', 'Repeat with Offset', '', '', 3),
-                    ('MIRROR', 'Mirrored', '', '', 4)]
+                     ('REPEAT', 'Repeat', '', '', 2),
+                     ('REPEAT_OFFSET', 'Repeat with Offset', '', '', 3),
+                     ('MIRROR', 'Mirrored', '', '', 4)]
 
     cycle_before: EnumProperty(
         items=cycle_options,
@@ -197,10 +171,10 @@ class AnimSlider(PropertyGroup):
                               description='use markers for the reference frames')
 
     affect_non_selected_fcurves: BoolProperty(default=True,
-                                           description='Affect non-selected fcurves')
+                                              description='Affect non-selected fcurves')
 
     affect_non_selected_keys: BoolProperty(default=False,
-                                            description='Affect non-selected keys when cursor is over them')
+                                           description='Affect non-selected keys when cursor is over them')
 
     min_value: FloatProperty(default=-1)
 
@@ -319,5 +293,5 @@ classes = (
     AnimAideAnimTransform,
     AnimAideClone,
     AnimSlider,
-    AnimAideScene
+    AnimAideScene,
 )

--- a/ui.py
+++ b/ui.py
@@ -40,10 +40,10 @@ def step_button(row, slot, factor, icon='',
     # else:
     #     step = col.operator('animaide.sliders', text=text, icon=icon, emboss=emboss)
 
-    if icon == '':
-        step = col.operator('animaide.%s' % str(slot.selector).lower(), text=text, emboss=emboss)
-    else:
-        step = col.operator('animaide.%s' % str(slot.selector).lower(), text=text, icon=icon, emboss=emboss)
+    kwargs = dict(operator='animaide.%s' % str(slot.selector).lower(),
+                  text=text, emboss=emboss)
+    if icon: kwargs['icon'] = icon
+    step = col.operator(**kwargs)
 
     step.factor = factor
     step.slope = slot.slope
@@ -84,11 +84,11 @@ def slider_box(layout, slot, index=-1):
     row.active = True
     row.operator_context = 'EXEC_DEFAULT'
 
-    if slot.modal_switch == False:
+    if not slot.modal_switch:
         # when slider is not active
 
         # left overshoot extra buttons
-        if slot.overshoot == True:
+        if slot.overshoot:
             for f in [-2, -1.5]:
                 step_button(row, slot, factor=f, text=' ', icon='')
 
@@ -114,7 +114,7 @@ def slider_box(layout, slot, index=-1):
                     icon='CHECKBOX_DEHLT', emboss=False, active=True)
 
         # right overshoot extra buttons
-        if slot.overshoot == True:
+        if slot.overshoot:
             for f in [1.5, 2]:
                 step_button(row, slot, factor=f, text=' ', icon='')
 
@@ -335,8 +335,3 @@ classes = (
     AAT_MT_pie_menu_a,
     AAT_MT_pie_menu_b
 )
-
-
-
-
-

--- a/utils.py
+++ b/utils.py
@@ -34,7 +34,7 @@ def gradual(key_y, target_y, delta=1.0, factor=0.15):
     print('source: ', key_y)
     print('target: ', target_y)
     print('factor: ', factor)
-    step = abs(key_y - target_y)*(delta*factor)
+    step = abs(key_y - target_y) * (delta * factor)
     print('gap: ', key_y - target_y)
     print('step: ', step)
 
@@ -116,4 +116,3 @@ def toggle(to_toggle, value_a, value_b):
         return value_b
     elif to_toggle == value_b:
         return value_a
-


### PR DESCRIPTION
The bulk of changes are just tweaks to how the code is written.
Functionally, the only difference here should be that
1) If an object doesn't have an action but the code still checks it, it won't result in an error
2) If an action's fcurve doesn't have a group, it can still be manipulated.