### PR TITLE
Blender UI vocabulary correction

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,7 +28,7 @@ bl_info = {
     "author": "Ares Deveaux",
     "version": (0, 1, 0),
     "blender": (2, 80, 0),
-    "location": "Graph Editor > Side Panel",
+    "location": "Graph Editor > Sidebar",
     "warning": "This addon is still in development.",
     "category": "Animation",
     "wiki_url": "https://github.com/aresdevo/animaide",


### PR DESCRIPTION
Smallest pr ever \o/
Just a little correction in the addon info section: the location was named "*Side Panel*" but according to the [official manual](https://docs.blender.org/manual/en/latest/interface/window_system/regions.html), that region is called the "*Sidebar*".