### PR TITLE
Add "Blend Default" slider and other small fixes

### DIFF
--- a/curve_tools/ops.py
+++ b/curve_tools/ops.py
@@ -407,13 +407,80 @@ class ANIMAIDE_OT_blend_neighbor(Operator, ANIMAIDE_OT):
     def execute(self, context):
         return support.to_execute(self, context, self.tool, context)
 
+class ANIMAIDE_OT_blend_default(Operator, ANIMAIDE_OT):
+    """Blend selected or current keys to the value of the default value"""
+
+    bl_idname = "anim.aide_blend_default"
+    bl_label = "Blend Default"
+
+    tool_type = 'BLEND_DEFAULT'
+
+    def tool(self, context):
+
+        if self.selected_keys:
+            if self.op_context == 'INVOKE_DEFAULT':
+                context.window.workspace.status_text_set(self.display_info)
+            tool = context.scene.animaide.tool
+            factor = utils.clamp(self.factor, self.min_value, self.max_value)
+            factor_zero_one = (factor+1)/(2)
+            for index in self.selected_keys:
+                default = None
+                id =  self.fcurve.id_data
+                datap = self.fcurve.data_path
+                obj = next(o for o in bpy.data.objects if o.animation_data and o.animation_data.action is id)
+
+                print("OBJECT: "+ str(obj))
+                if obj.type == "ARMATURE" and bpy.context.mode == "POSE":
+                    names = datap.split('"')[1::2]
+                    data_path_no_names = ''.join(datap.split('"')[0::2])
+
+                    data_chunks = data_path_no_names.replace('][', '].[').split('.')
+                    for id, chunk in enumerate(data_chunks):
+                        if chunk.find('[]') > 0:
+                            data_chunks[id] = chunk.replace('[]', '["' + names.pop(0) + '"]')
+
+                    boneName = data_chunks[1].split('"')[1::2]
+
+                    print(str(data_chunks))              
+
+                    default = obj.pose.bones[boneName[0]].bl_rna.properties[data_chunks[2]]
+                else:
+                    if obj.get(datap) == None and obj.type != "ARMATURE":
+                        default = obj.bl_rna.properties[datap]
+
+                if default:
+                    if default.default_array:
+                        default = default.default_array[self.fcurve.array_index]
+                    else:
+                        default = default.default
+                else:
+                    default = self.original_values[index]['y'] # Unsupported object, dont affect it
+
+                k = self.fcurve.keyframe_points[index]
+                print(factor)
+                new_value = (default*factor)+(self.original_values[index]['y']*(1-factor))
+                if tool.sticky_handles and context.area.type == 'GRAPH_EDITOR':
+                    k.co.y = new_value
+                else:
+                    k.co_ui.y = new_value
+
+        elif context.scene.tool_settings.use_keyframe_insert_auto:
+            context.window.workspace.status_text_set(self.display_info)
+            self.add_key(context, self.fcurve)
+        # else:
+        #     self.report({'INFO'}, self.warning)
+        return
+
+    def execute(self, context):
+        return support.to_execute(self, context, self.tool, context)
+
 
 class ANIMAIDE_OT_blend_infinite(Operator, ANIMAIDE_OT):
     """Blend selected or current keys to the slant of neighboring\n""" \
     """left or right keys."""
 
     bl_idname = "anim.aide_blend_infinite"
-    bl_label = "Blend infinite"
+    bl_label = "Blend Infinite"
 
     tool_type = 'BLEND_INFINITE'
 
@@ -1189,6 +1256,7 @@ classes = (
     ANIMAIDE_OT_blend_ease,
     ANIMAIDE_OT_blend_neighbor,
     ANIMAIDE_OT_blend_frame,
+    ANIMAIDE_OT_blend_default,
     ANIMAIDE_OT_blend_offset,
     ANIMAIDE_OT_push_pull,
     ANIMAIDE_OT_scale_average,

--- a/curve_tools/ops.py
+++ b/curve_tools/ops.py
@@ -408,7 +408,7 @@ class ANIMAIDE_OT_blend_neighbor(Operator, ANIMAIDE_OT):
         return support.to_execute(self, context, self.tool, context)
 
 class ANIMAIDE_OT_blend_default(Operator, ANIMAIDE_OT):
-    """Blend selected or current keys to the value of the default value"""
+    """Blend selected or current keys to the default value"""
 
     bl_idname = "anim.aide_blend_default"
     bl_label = "Blend Default"

--- a/curve_tools/props.py
+++ b/curve_tools/props.py
@@ -31,37 +31,39 @@ menu_items = [('BLEND_EASE', 'Blend Ease', 'From current to C shape', '', 1),
               ('BLEND_FRAME', 'Blend Frame', 'From current to set frames', '', 2),
               ('BLEND_INFINITE', 'Blend Infinite', 'Adds or adjust keys to conform to the adjacent slope', '', 3),
               ('BLEND_NEIGHBOR', 'Blend Neighbor', 'From current to neighbors', '', 4),
-              ('BLEND_OFFSET', 'Blend Offset', 'Offset key values to neighbors', '', 5),
+              ('BLEND_DEFAULT', 'Blend Default', 'From default value', '', 5),
+              ('BLEND_OFFSET', 'Blend Offset', 'Offset key values to neighbors', '', 6),
 
-              ('EASE', 'Ease', 'C shape transition', '', 6),
-              ('EASE_TO_EASE', 'Ease To Ease', 'S shape transition', '', 7),
+              ('EASE', 'Ease', 'C shape transition', '', 7),
+              ('EASE_TO_EASE', 'Ease To Ease', 'S shape transition', '', 8),
 
-              ('SCALE_AVERAGE', 'Scale Average', 'Scale to average value', '', 8),
-              ('SCALE_LEFT', 'Scale Left', 'Scale anchor to left neighbor', '', 9),
-              ('SCALE_RIGHT', 'Scale Right', 'Scale anchor to right neighbor', '', 10),
+              ('SCALE_AVERAGE', 'Scale Average', 'Scale to average value', '', 9),
+              ('SCALE_LEFT', 'Scale Left', 'Scale anchor to left neighbor', '', 10),
+              ('SCALE_RIGHT', 'Scale Right', 'Scale anchor to right neighbor', '', 11),
 
-              ('SHEAR_LEFT', 'Shear Left', 'Overshoots key values', '', 11),
-              ('SHEAR_RIGHT', 'Shear Right', 'Overshoots key values', '', 12),
+              ('SHEAR_LEFT', 'Shear Left', 'Overshoots key values', '', 12),
+              ('SHEAR_RIGHT', 'Shear Right', 'Overshoots key values', '', 13),
 
-              ('PUSH_PULL', 'Push Pull', 'Overshoots key values', '', 13),
-              ('TIME_OFFSET', 'Time Offset', 'Slide fcurve in time without afecting keys frame value', '', 14),
-              ('TWEEN', 'Tween', 'Sets key value using neighbors as reference', '', 15),
+              ('PUSH_PULL', 'Push Pull', 'Overshoots key values', '', 14),
+              ('TIME_OFFSET', 'Time Offset', 'Slide fcurve in time without afecting keys frame value', '', 15),
+              ('TWEEN', 'Tween', 'Sets key value using neighbors as reference', '', 16),
 
-              ('SMOOTH', 'Smooth', 'Smooths out fcurve keys', '', 16),
-              ('WAVE_NOISE', 'Wave-Noise', 'add wave or random values to keys', '', 17)]
+              ('SMOOTH', 'Smooth', 'Smooths out fcurve keys', '', 17),
+              ('WAVE_NOISE', 'Wave-Noise', 'add wave or random values to keys', '', 18)]
 
 
 menu_items_3d = [('BLEND_FRAME', 'Blend Frame', 'From current to set frames', '', 1),
                  ('BLEND_INFINITE', 'Blend Infinite', 'Adds or adjust keys to conform to the adjacent slope', '', 2),
                  ('BLEND_NEIGHBOR', 'Blend Neighbor', 'From current to neighbors', '', 3),
+                 ('BLEND_DEFAULT', 'Blend Default', 'From default value', '', 4),
 
-                 ('SCALE_LEFT', 'Scale Left', 'Scale anchor to left neighbor', '', 4),
-                 ('SCALE_RIGHT', 'Scale Right', 'Scale anchor to right neighbor', '', 5),
+                 ('SCALE_LEFT', 'Scale Left', 'Scale anchor to left neighbor', '', 5),
+                 ('SCALE_RIGHT', 'Scale Right', 'Scale anchor to right neighbor', '', 6),
 
-                 ('PUSH_PULL', 'Push Pull', 'Overshoots key values', '', 6),
+                 ('PUSH_PULL', 'Push Pull', 'Overshoots key values', '', 7),
 
-                 ('TIME_OFFSET', 'Time Offset', 'Slide fcurve in time without afecting keys frame value', '', 7),
-                 ('TWEEN', 'Tween', 'Sets key value using neighbors as reference', '', 8)]
+                 ('TIME_OFFSET', 'Time Offset', 'Slide fcurve in time without afecting keys frame value', '', 8),
+                 ('TWEEN', 'Tween', 'Sets key value using neighbors as reference', '', 9)]
 
 
 def update_clone_move(self, context):

--- a/curve_tools/ui.py
+++ b/curve_tools/ui.py
@@ -219,6 +219,7 @@ class ANIMAIDE_PT_curve_tools:
             tool_button(context, col, 'blend_frame')
             tool_button(context, col, 'blend_infinite')
             tool_button(context, col, 'blend_neighbor')
+            tool_button(context, col, 'blend_default')
             if context.area.type != 'VIEW_3D':
                 tool_button(context, col, 'blend_offset')
                 col.separator()
@@ -349,6 +350,7 @@ class ANIMAIDE_MT_curve_tools(Menu):
         layout.operator('anim.aide_blend_frame')
         layout.operator('anim.aide_blend_infinite')
         layout.operator('anim.aide_blend_neighbor')
+        layout.operator('anim.aide_blend_default')
         if context.area.type != 'VIEW_3D':
             layout.operator('anim.aide_blend_offset')
 
@@ -432,6 +434,7 @@ class ANIMAIDE_MT_pie_curve_tools_b(Menu):
         pie.operator("anim.aide_smooth")
         pie.operator("anim.aide_blend_offset")
         pie.operator("anim.aide_time_offset")
+        pie.operator("anim.aide_blend_default")
         pie.operator('anim.aide_blend_infinite')
 
 

--- a/key_manager/support.py
+++ b/key_manager/support.py
@@ -160,13 +160,13 @@ def change_frame(context, amount, direction='RIGHT'):
 
     if lonely_cursor and not some_selected_key:
         if direction == 'LEFT' and left_limit:
-            context.scene.frame_current = left_limit
+            context.scene.frame_current = int(left_limit)
         elif direction == 'RIGHT' and right_limit:
-            context.scene.frame_current = right_limit
+            context.scene.frame_current = int(right_limit)
     elif some_selected_key:
-        context.scene.frame_current = mid + amount
+        context.scene.frame_current = int(mid + amount)
     else:
-        context.scene.frame_current += frames
+        context.scene.frame_current += int(frames)
 
 
 def insert_frames(context, amount):


### PR DESCRIPTION
This PR introduces a couple changes:

- Fix for requiring int value while nudging keys as of Blender 3.1
- Add Capital "i" to Blend Infinite in curve tools sliders
- Add Blend Default Slider (example shown in video below):
   * Supports object-level and bone-level transforms
   * Works in Viewport and Graph Editor
   * Factor of 0 will do nothing
   * Factor of 1 will blend the object to channel's default value
   * Factor of -1 will transform the channel in relation to the default value (similar to blend infinite)
  
   * Current limitations
      * Does not work with custom properties (I'm unable to find a way to read a custom property's default value)
      * Does not work with constraints or shape keys

 * Add Blend Default to Pie Group B

https://user-images.githubusercontent.com/43157991/185308413-b55ed88d-8e24-475b-9c3d-5793fe05a2f6.mp4